### PR TITLE
enforce some dependency versions for consistent install

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ irm https://astral.sh/uv/install.ps1 | iex
 Create a virtual environment and install dependencies:
 
 ```bash
-# Create a virtual environment
-uv venv .venv
+# Create a virtual environment (recommended: python3.11+ for dependency issues, not mandatory)
+python3.11 -m uv venv .venv
 
 # Activate the virtual environment
 # On macOS/Linux:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+llvmlite>=0.40.0
+numba>=0.56.0
+
 numpy
 pandas
 nibabel


### PR DESCRIPTION
python 3.11, set mamba/llvmlite version requirements

llvmlite version had issues with previous installation instructions